### PR TITLE
Make each locust "user" internally parallelized

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -1,4 +1,11 @@
+from itertools import product
+
 from locust import HttpUser, task, between
+from gevent.pool import Pool
+
+# This value is intended to reflect the number of simultaneous requests a typical web browser
+# makes while actively interacting with the tile server.
+CLIENT_CONCURRENCY = 5
 
 
 class HistomicsUser(HttpUser):
@@ -13,18 +20,29 @@ class HistomicsUser(HttpUser):
         self.tile_metadata = self.client.get(
             f"item/{self.example_item_id}/tiles"
         ).json()
+        z = self.tile_metadata["levels"] - 1
+        self.all_tiles = [(z, y, x) for y, x in product(
+            range(int(self.tile_metadata["sizeY"] / self.tile_metadata["tileHeight"])),
+            range(int(self.tile_metadata["sizeX"] / self.tile_metadata["tileWidth"])),
+        )]
 
     @task
     def get_tiles(self):
-        # Attempt to get all tiles in image at greatest resolution
-        z = self.tile_metadata["levels"] - 1
-        for y in range(
-            int(self.tile_metadata["sizeY"] / self.tile_metadata["tileHeight"])
-        ):
-            for x in range(
-                int(self.tile_metadata["sizeX"] / self.tile_metadata["tileHeight"])
-            ):
+        tile_count = len(self.all_tiles)
+        tiles_per_worker = tile_count // CLIENT_CONCURRENCY
+
+        def fetch_tiles(start: int, count: int):
+            for z, y, x in self.all_tiles[start:start+count]:
                 self.client.get(
                     f"item/{self.example_item_id}/tiles/zxy/{z}/{x}/{y}",
                     name="/tiles/zxy/z/x/y",
                 )
+
+        pool = Pool()
+        for i in range(CLIENT_CONCURRENCY):
+            pool.spawn(
+                fetch_tiles,
+                start=int((i / CLIENT_CONCURRENCY) * tile_count),
+                count=tiles_per_worker
+            )
+        pool.join()


### PR DESCRIPTION
This is an attempt to make the user more like a real user, where each user will be sending up to 5 requests per second in parallel.

I'm not convinced we should actually merge this, but just wanted to show what it looked like and foster discussion. "Requests per second" seems like a far more important metric, so this may not be worth the extra complexity.

Note that it does fix one bug, which is that "tileHeight" was used twice instead of using both the width and height.